### PR TITLE
ADD: custom CSS within the head element to remove the paginator

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -1,0 +1,11 @@
+<!-- start custom head snippets -->
+
+<style>
+.pagination {
+     display: none;
+}
+</style>
+
+<!-- insert favicons. use https://realfavicongenerator.net/ -->
+
+<!-- end custom head snippets -->


### PR DESCRIPTION
This PR adds a `custom.html` file to the head element of the site. Within this file is a CSS directive to hide the pagination elements.

Closes #11 